### PR TITLE
Update Modep plugin directory

### DIFF
--- a/sys_lv2_to_modep_lv2.sh
+++ b/sys_lv2_to_modep_lv2.sh
@@ -3,7 +3,7 @@
 # symlink system LV2 into MODEP lv2 dir
 
 sys_lv2_dir=/usr/lib/lv2
-modep_lv2_dir=/usr/local/modep/.lv2
+modep_lv2_dir=/usr/modep/lv2
 
 # for every plugin
 for sys_lv2 in $(ls -1tr $sys_lv2_dir) ; do


### PR DESCRIPTION
The Modep plugin directory has changed in the most recent update. This is the new directory.

This fixes my error I reported here https://community.blokas.io/t/quickly-easily-getting-more-lv2-plugins/1277/2?u=elijahlynn: 
> ln: failed to create symbolic link ‘/usr/local/modep/.lv2/decay-swh.lv2’: No such file or directory